### PR TITLE
Fixed some bugs

### DIFF
--- a/class.cpp
+++ b/class.cpp
@@ -35,14 +35,14 @@ class Minefield
   	{
     		return;
   	}
-  	is_swept[i][j]=true;
+  	
   	number[i][j]=s; //changing the zeros to s (which helps us to identify the zeros which have opened)   s is purely a placeholder
   	state[i][j] = swept_char; //changing the state array which is printed at the end
   	sweep_util(i-1,j,s);
   	sweep_util(i+1,j,s);
   	sweep_util(i,j-1,s);
   	sweep_util(i,j+1,s);
-    sweep_util(i-1,j-1,s);
+    	sweep_util(i-1,j-1,s);
   	sweep_util(i+1,j+1,s);
   	sweep_util(i+1,j-1,s);
   	sweep_util(i-1,j+1,s);
@@ -200,19 +200,21 @@ class Minefield
 	       {
 	           is_flagged[i][j]=false;
 	           num_flagged-=1;
+		   state[i][j]=unswept_char;
 	       }
 	       if(is_q_marked[i][j])
 	       {
 	           is_q_marked[i][j]=false;
+		   state[i][j]=unswept_char;
 	       }
-	       state[i][j]=unswept_char;
+	       
         
     }
      void sweep_from(int i, int j) // the main function which tackles all inputs of position (which are not visited) other that flag and question mark
 	//assuming that flag and question mark functions are called before hand only and the given position cannot have those two.
     {
     
-	is_swept[i][j]=true;
+	
     	if(is_mine[i][j])
  	{
     		state[i][j]=mine_char;
@@ -222,10 +224,13 @@ class Minefield
   	}
   	//bomb tackled
   	// now handling numbers
-    int s = -9; // placeholder
+    	int s = -9; // placeholder
 
   	if(number[i][j]!=0&&number[i][j]!=s)
   	{
+		if(state[i][j]==flag_char||state[i][j]==q_mark_char)
+			clear(i,j);
+		
     		state[i][j]=(char)(48+number[i][j]);
 		num_swept++;
     		return;
@@ -242,11 +247,17 @@ class Minefield
    	{
     		for(m=0;m<c;m++)
     		{
+			bool is_tile_flagged=false;
+			bool is_tile_q_mark=false;
+			if(state[l][m]==flag_char)
+				is_tile_flagged=true;
+			if(state[l][m]==q_mark_char)
+				is_tile_q_mark-true;
       			if(l==0&&m==0) // checking top left corner
       			{ 
 				if((number[1][0]==s||number[1][1]==s||number[0][1]==s)&&number[0][0]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
           				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
@@ -254,7 +265,7 @@ class Minefield
       			{ 
 				if((number[0][c-2]==s||number[1][c-2]==s||number[1][c-1]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
           				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
@@ -262,7 +273,7 @@ class Minefield
       			{ 
 				if((number[r-2][0]==s||number[r-2][1]==s||number[r-1][1]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
           				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
@@ -270,7 +281,7 @@ class Minefield
       			{ 
 				if((number[r-1][c-2]==s||number[r-2][c-2]==s||number[r-2][c-1]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
           				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
@@ -278,7 +289,7 @@ class Minefield
       			{ 
 				if((number[l][m-1]==s||number[l][m+1]==s||number[l+1][m-1]==s||number[l+1][m]==s||number[l+1][m+1]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
           				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
@@ -286,7 +297,7 @@ class Minefield
       			{ 
 				if((number[l-1][m]==s||number[l-1][m+1]==s||number[l][m+1]==s||number[l+1][m]==s||number[l+1][m+1]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
           				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
@@ -294,7 +305,7 @@ class Minefield
       			{ 
 				if((number[l-1][m-1]==s||number[l-1][m]==s||number[l][m-1]==s||number[l+1][m-1]==s||number[l+1][m]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
 					state[l][m]=(char)(48+number[l][m]);
 				}
 			}
@@ -302,21 +313,27 @@ class Minefield
       			{ 
 				if((number[l-1][m-1]==s||number[l-1][m]==s||number[l-1][m+1]==s||number[l][m-1]==s||number[l][m+1]==s)&&number[l][m]!=s)
 				{
-          				is_swept[l][m]=true;
+          				
          				state[l][m]=(char)(48+number[l][m]);
         			}
       			}
       			else if((number[l-1][m-1]==s||number[l-1][m]==s||number[l-1][m+1]==s||number[l][m-1]==s||number[l][m+1]==s||number[l+1][m-1]==s||number[l+1][m]==s||number[l+1][m+1]==s)&&number[l][m]!=s)
       			{
-        			is_swept[l][m]=true;
+        			
         			state[l][m]=(char)(48+number[l][m]);
       			}
 
-      			if(is_swept[l][m])
+      			if(state[l][m]!=unswept_char&&state[l][m]!=q_mark_char&&state[l][m]!=flag_char)
 	    		num_swept++;
 
-      		if(is_flagged[l][m]&&state[l][m]!=flag_char || is_q_marked[l][m]&&state[l][m]!=q_mark_char)
-            	{clear(l,m);state[l][m]=swept_char;}
+      		if(is_tile_flagged&&state[l][m]!=flag_char || is_tile_q_mark&&state[l][m]!=q_mark_char)
+            	{clear(l,m);
+		 
+		 
+		 if(number[l][m]==s)
+		 state[l][m]=swept_char;
+		else
+		state[l][m]=(char)(48+number[l][m]);}
             
       		
 
@@ -349,6 +366,11 @@ class Minefield
     {
         return c;
     }
+    int get_num_swept()
+    {
+        return num_swept;
+    }
+   
     int get_num_of(int i,int j){return number[i][j];}
 };
 
@@ -428,7 +450,10 @@ int main()
     {
         clear();
         print(m);
-        cout<<'\n';
+	cout<<endl;
+        cout<<"Number of tiles swept = "<<m.get_num_swept()<<endl;
+        cout<<"Number of flags = "<<m.get_num_flags()<<endl;
+	cout<<'\n';
         cin>>input;
         if(input == 'e')break;
         cin>>i>>j;


### PR DESCRIPTION
The clear function was clearing even the swept tiles like numbers with 0 and 1,2,... so on which should not be the case, Hence I wrote updated state inside if condition
Added the get_num_swept function in Minefield class and added printing statements which shows how many tiles are swept and how many flags are there.
Next, removed the is_flagged array and is_q_marked array and is_swept array from the two functions sweep_util() and sweep_from()
There was a bug in sweep_from function which swept the flagged tiles without changing the number of flags. Hence that is tackled. i.e. the sweep_from function now tackles falgged and q_marked tiles too if they are swept.
There was another bug in sweep_from function that if we flagged a non-zero neighbour and later swept it's zero neighbour, the non-zero neighbour tiled showed  swept_char i.e. 'o' which shuld not be the case. Hence I fixed it line 333-336.
Try running the code after I removed superfluous arrays from the sweep functions.